### PR TITLE
Navigation restrictions for users and merchants

### DIFF
--- a/spec/features/users/merchant_nav_spec.rb
+++ b/spec/features/users/merchant_nav_spec.rb
@@ -8,12 +8,31 @@ RSpec.describe 'As a Merchant' do
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    visit '/'
+    visit welcome_path
 
     within 'nav' do
       click_link 'Merchant Dashboard'
     end
 
     expect(current_path).to eq('/merchant')
+  end
+
+  it 'employee or admin I do not have access to site admin dashboard' do
+    merchant_employee = User.create(username: 'funbucket13', password: 'secure', role: 1)
+    merchant_admin = User.create(username: 'funbucket13', password: 'secure', role: 2)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_employee)
+
+    visit admin_path
+
+    expect(current_path).to eq(admin_path)
+    expect(page).to have_content('The page you were looking for doesn\'t exist.')
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_admin)
+
+    visit admin_path
+
+    expect(current_path).to eq(admin_path)
+    expect(page).to have_content('The page you were looking for doesn\'t exist.')
   end
 end

--- a/spec/features/users/navigation_spec.rb
+++ b/spec/features/users/navigation_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe 'As a User' do
 
       expect(current_path).to eq('/logout')
     end
+
+    it 'restricts access to merchant and admin dashboards' do
+      user = User.create(username: 'funbucket12', password: 'secure')
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit admin_path
+
+      expect(current_path).to eq(admin_path)
+      expect(page).to have_content('The page you were looking for doesn\'t exist.')
+
+      visit merchant_dashboard_path
+
+      expect(current_path).to eq(merchant_dashboard_path)
+      expect(page).to have_content('The page you were looking for doesn\'t exist.')
+    end
   end
 
   describe 'as a non-registered user' do


### PR DESCRIPTION
Create tests to verify restrictions on merchant employees, merchant admins, and regular users.

Co-Authored-By: Laura Schulz <lrs8810@users.noreply.github.com>
Co-Authored-By: Michael Cooper <CoopTang@users.noreply.github.com>
Co-Authored-By: Scott Regenthal <freeheeling@users.noreply.github.com>