### PR TITLE
User orders show and index pages

### DIFF
--- a/app/controllers/user_orders_controller.rb
+++ b/app/controllers/user_orders_controller.rb
@@ -2,4 +2,8 @@ class UserOrdersController < ApplicationController
 
   def index; end
 
+  def show
+    @order = Order.find(params[:id])
+  end
+
 end

--- a/app/controllers/user_orders_controller.rb
+++ b/app/controllers/user_orders_controller.rb
@@ -1,0 +1,5 @@
+class UserOrdersController < ApplicationController
+
+  def index; end
+
+end

--- a/app/controllers/user_orders_controller.rb
+++ b/app/controllers/user_orders_controller.rb
@@ -3,7 +3,8 @@ class UserOrdersController < ApplicationController
   def index; end
 
   def show
-    @order = Order.find(params[:id])
+    @order = Order.where(id: params[:id], user_id: current_user.id).first
+    render_404 unless @order
   end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,7 +9,11 @@ class Order < ApplicationRecord
 
   enum status: %w[Pending Packaged Shipped Cancelled]
 
-  def grandtotal
+  def grand_total
     item_orders.sum('price * quantity')
+  end
+
+  def total_quantity
+    item_orders.sum(:quantity)
   end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -43,7 +43,7 @@
 </table>
 
 <section id="grandtotal">
-  <p>Total: <%=number_to_currency(@order.grandtotal)%></p>
+  <p>Total: <%=number_to_currency(@order.grand_total)%></p>
 </section>
 <section id="datecreated">
   <p> <%= @order.created_at%></p>

--- a/app/views/partials/_order_info.html.erb
+++ b/app/views/partials/_order_info.html.erb
@@ -1,0 +1,6 @@
+<p>ID: <%= link_to "#{id}", profile_order_path(id) %></p>
+<p>Date Created: <%= created_at %></p>
+<p>Last Updated: <%= updated_at %></p>
+<p>Status: <%= status %></p>
+<p>Total Quantity: <%= total_quantity %></p>
+<p>Grand Total: <%= grand_total %></p>

--- a/app/views/partials/_order_info.html.erb
+++ b/app/views/partials/_order_info.html.erb
@@ -1,6 +1,17 @@
-<p>ID: <%= link_to "#{id}", profile_order_path(id) %></p>
 <p>Date Created: <%= created_at %></p>
 <p>Last Updated: <%= updated_at %></p>
 <p>Status: <%= status %></p>
+<% if item_orders %>
+  <% item_orders.each do |item_order| %>
+    <article id='item-order-<%= item_order.id %>'>
+      <p>Name: <%= item_order.item.name %></p>
+      <p>Description: <%= item_order.item.description %></p>
+      <img src= <%= item_order.item.image %>>
+      <p>Quantity: <%= item_order.quantity %></p>
+      <p>Price: <%= item_order.price %></p>
+      <p>Subtotal: <%= item_order.subtotal %></p>
+    </article>
+  <% end %>
+<% end %>
 <p>Total Quantity: <%= total_quantity %></p>
 <p>Grand Total: <%= grand_total %></p>

--- a/app/views/user_orders/index.html.erb
+++ b/app/views/user_orders/index.html.erb
@@ -1,0 +1,15 @@
+<h1>My Orders</h1>
+<% current_user.orders.each do |order| %>
+  <article id='order-<%= order.id %>'>
+    <%= render partial: 'partials/order_info',
+      locals: {
+        id: order.id,
+        created_at: order.created_at,
+        updated_at: order.updated_at,
+        status: order.status,
+        total_quantity: order.total_quantity,
+        grand_total: order.grand_total
+      }
+    %>
+  </article>
+<% end %>

--- a/app/views/user_orders/index.html.erb
+++ b/app/views/user_orders/index.html.erb
@@ -1,12 +1,14 @@
 <h1>My Orders</h1>
 <% current_user.orders.each do |order| %>
   <article id='order-<%= order.id %>'>
+  <p>ID: <%= link_to "#{order.id}", profile_order_path(order) %></p>
     <%= render partial: 'partials/order_info',
       locals: {
         id: order.id,
         created_at: order.created_at,
         updated_at: order.updated_at,
         status: order.status,
+        item_orders: nil,
         total_quantity: order.total_quantity,
         grand_total: order.grand_total
       }

--- a/app/views/user_orders/show.html.erb
+++ b/app/views/user_orders/show.html.erb
@@ -1,0 +1,14 @@
+<h1>ID: <%= @order.id %></h1>
+<article id='order-info'>
+  <%= render partial: 'partials/order_info',
+    locals: {
+      id: @order.id,
+      created_at: @order.created_at,
+      updated_at: @order.updated_at,
+      status: @order.status,
+      item_orders: @order.item_orders,
+      total_quantity: @order.total_quantity,
+      grand_total: @order.grand_total
+    }
+  %>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,9 +26,11 @@ Rails.application.routes.draw do
   get '/profile', to: 'users#show'
   get '/profile/edit', to: 'users#edit_profile'
   get '/profile/edit_password', to: 'users#edit_password'
-  get '/profile/orders', to: 'users#show' # Change this when we come up with a solution
   patch '/profile/update', to: 'users#update_profile'
   patch '/profile/update_password', to: 'users#update_password'
+  
+  get '/profile/orders', to: 'user_orders#index'
+  get '/profile/orders/:id', to: 'user_orders#show', as: 'profile_order'
 
   get '/login', to: 'sessions#login'
   post '/login', to: 'sessions#create', as: 'login_create'

--- a/spec/features/user_orders/index_spec.rb
+++ b/spec/features/user_orders/index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'As a registered user' do
 
       tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
       pull_toy = brian.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
-      
+
       user = User.create(
         name: 'Bob',
         address: '123 Main',
@@ -32,7 +32,7 @@ RSpec.describe 'As a registered user' do
         expect(page).to have_content("Date Created: #{order_1.created_at}")
         expect(page).to have_content("Last Updated: #{order_1.updated_at}")
         expect(page).to have_content("Status: #{order_1.status}")
-        expect(page).to have_content("Total Items: #{order_1.total_items}")
+        expect(page).to have_content("Total Quantity: #{order_1.total_quantity}")
         expect(page).to have_content("Grand Total: #{order_1.grand_total}")
       end
     end

--- a/spec/features/user_orders/index_spec.rb
+++ b/spec/features/user_orders/index_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user' do
+  describe 'When I visit my profile orders page' do
+    it 'displays every order I have made and their info' do
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      brian = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
+
+      tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+      pull_toy = brian.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
+      
+      user = User.create(
+        name: 'Bob',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'bob@email.com',
+        password: 'secure'
+      )
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      order_1 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033)
+
+      order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
+      order_1.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 3)
+
+      visit profile_orders_path
+
+      within "order-#{order_1.id}" do
+        expect(page).to have_link("ID: #{order_1.id}")
+        expect(page).to have_content("Date Created: #{order_1.created_at}")
+        expect(page).to have_content("Last Updated: #{order_1.updated_at}")
+        expect(page).to have_content("Status: #{order_1.status}")
+        expect(page).to have_content("Total Items: #{order_1.total_items}")
+        expect(page).to have_content("Grand Total: #{order_1.grand_total}")
+      end
+    end
+  end
+end

--- a/spec/features/user_orders/index_spec.rb
+++ b/spec/features/user_orders/index_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'As a registered user' do
 
       visit profile_orders_path
 
-      within "order-#{order_1.id}" do
-        expect(page).to have_link("ID: #{order_1.id}")
+      within "#order-#{order_1.id}" do
+        expect(page).to have_link("#{order_1.id}")
         expect(page).to have_content("Date Created: #{order_1.created_at}")
         expect(page).to have_content("Last Updated: #{order_1.updated_at}")
         expect(page).to have_content("Status: #{order_1.status}")

--- a/spec/features/user_orders/show_spec.rb
+++ b/spec/features/user_orders/show_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user' do
+  describe 'When I visit a profile order show page' do
+    it 'displays the order with all info' do
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      brian = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
+
+      tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+      pull_toy = brian.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
+
+      user = User.create(
+        name: 'Bob',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'bob@email.com',
+        password: 'secure'
+      )
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      order_1 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033)
+
+      item_order_1 = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
+      item_order_2 = order_1.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 3)
+
+      visit profile_order_path(order_1)
+
+      expect(page).to have_content("ID: #{order_1.id}")
+
+      within "#order-info" do
+        expect(page).to have_content("Date Created: #{order_1.created_at}")
+        expect(page).to have_content("Last Updated: #{order_1.updated_at}")
+        expect(page).to have_content("Status: #{order_1.status}")
+        expect(page).to have_content("Total Quantity: #{order_1.total_quantity}")
+        expect(page).to have_content("Grand Total: #{order_1.grand_total}")
+      end
+
+      within "#item-order-#{item_order_1.id}" do
+        expect(page).to have_content("Name: #{tire.name}")
+        expect(page).to have_content("Description: #{tire.description}")
+        expect(page).to have_css("img[src*='#{tire.image}']")
+        expect(page).to have_content("Quantity: #{item_order_1.quantity}")
+        expect(page).to have_content("Price: #{item_order_1.price}")
+        expect(page).to have_content("Subtotal: #{item_order_1.subtotal}")
+      end
+
+      within "#item-order-#{item_order_2.id}" do
+        expect(page).to have_content("Name: #{pull_toy.name}")
+        expect(page).to have_content("Description: #{pull_toy.description}")
+        expect(page).to have_css("img[src*='#{pull_toy.image}']")
+        expect(page).to have_content("Quantity: #{item_order_2.quantity}")
+        expect(page).to have_content("Price: #{item_order_2.price}")
+        expect(page).to have_content("Subtotal: #{item_order_2.subtotal}")
+      end
+    end
+  end
+end

--- a/spec/features/user_orders/show_spec.rb
+++ b/spec/features/user_orders/show_spec.rb
@@ -55,5 +55,28 @@ RSpec.describe 'As a registered user' do
         expect(page).to have_content("Subtotal: #{item_order_2.subtotal}")
       end
     end
+
+    it 'renders a 404 if the show page does not exist' do
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      brian = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
+
+      tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+      pull_toy = brian.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
+
+      user = User.create(
+        name: 'Bob',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'bob@email.com',
+        password: 'secure'
+      )
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit profile_order_path(999999)
+
+      expect(page).to have_content('The page you were looking for doesn\'t exist.')
+    end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -38,8 +38,15 @@ describe Order, type: :model do
       @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)
     end
+
     it 'grandtotal' do
-      expect(@order_1.grandtotal).to eq(230)
+      expect(@order_1.grand_total).to eq(230)
     end
+    
+    it 'total_quantity' do
+      expect(@order_1.total_quantity).to eq(5)
+    end
+
+
   end
 end


### PR DESCRIPTION
- (#18) Add profile orders index page to view all a user's orders.
- (#17) Add profile orders show page to view a single order by a user. Also added sad path for users that try to access orders that don't exist or don't belong to the current user.