### PR TITLE
Add deactivate item functionality from merchant items index page 

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
 class Merchant::ItemsController < Merchant::BaseController
-  def index; end
+  def index
+    @items = current_user.merchant.items
+  end
+
+  def activate_deactivate
+    if params[:activate_deactivate] == 'deactivate'
+      item = Item.find(params[:item_id])
+      item.toggle!(:active?)
+      flash[:notice] = "#{item.name} is now deactivated and is no longer for sale."
+      redirect_to merchant_user_items_path
+    end
+  end
 end

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,0 +1,10 @@
+<h1>All My Items</h1>
+
+<% @items.each do |item| %>
+  <section id= "item-<%= item.id %>">
+    <%= item.name %>
+    <% if item.active? %>
+      <%= link_to 'Deactivate Item', "/merchant/items/#{item.id}/deactivate", method: :patch %>
+    <% end %>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,5 +45,6 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index', as: 'dashboard'
     get '/items', to: 'items#index', as: 'user_items'
     get '/orders/:order_id', to: 'orders#show'
+    patch '/items/:item_id/:activate_deactivate', to: 'items#activate_deactivate'
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', c
 
 # bike_shop items
 tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
-pump = bike_shop.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', inventory: 15)
+pump = bike_shop.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', active?: false, inventory: 15)
 helmet = bike_shop.items.create(name: 'Helmet', description: 'Protects your brain. Try it!', price: 15, image: 'https://www.rei.com/media/product/1289320004', inventory: 20)
 
 # dog_shop items
@@ -45,13 +45,12 @@ dog_bowl.reviews.create(title: "It's okay.", content: 'Not that bad, I guess.', 
 dog_bowl.reviews.create(title: 'Amazing!', content: 'Truly changed my life!', rating: 5)
 
 # regular user
-user = User.create(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user@user.com', password: 'secure', role: 0)
+user = User.create(name: 'User', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user@user.com', password: 'secure', role: 0)
 
 # merchant employee
-user = User.create(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'merchant_employee@user.com', password: 'secure', role: 1)
+user = bike_shop.users.create(name: 'Merchant Employee', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'merchant_employee@user.com', password: 'secure', role: 1)
 
 # merchant admin
-user = User.create(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'merchant_admin@user.com', password: 'secure', role: 2)
 
 # site admin
-user = User.create(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+user = User.create(name: 'Site Admin', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)

--- a/spec/features/users/merchant_items_spec.rb
+++ b/spec/features/users/merchant_items_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'As a Merchant Admin' do
+  describe 'on my items page' do
+    it 'I see a link to deactivate an active item' do
+      meg = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      merchant_admin = meg.users.create(
+        name: 'Admin',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'bob@email.com',
+        password: 'secure',
+        role: 2
+      )
+      user = User.create!(
+        name: 'User',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'user@email.com',
+        password: 'secure'
+      )
+
+      tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+      helmet = meg.items.create(name: 'Helmet', description: 'Protects your brain. Try it!', price: 15, image: 'https://www.rei.com/media/product/1289320004', inventory: 20)
+      pump = meg.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', active?: false, inventory: 15)
+
+      order_1 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
+      order_2 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
+
+      order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
+      order_2.item_orders.create!(item: helmet, price: helmet.price, quantity: 2)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_admin)
+
+      visit merchant_user_items_path
+
+      within "#item-#{pump.id}" do
+        expect(page).to_not have_link('Deactivate Item')
+      end
+
+      within "#item-#{tire.id}" do
+        expect(page).to have_link('Deactivate Item')
+        click_link 'Deactivate Item'
+      end
+
+      expect(current_path).to eq(merchant_user_items_path)
+
+      tire.reload
+
+      expect(page).to have_content("#{tire.name} is now deactivated and is no longer for sale.")
+
+      expect(tire.active?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
**User Story (#60) – Merchant Admin can deactivate an item**
- activate_deactivate method added to Merchant::ItemsController to deactivate an active item
- Link added to merchant admin index page to deactivate an active item
- Flash message indicates item has successfully been deactivated and is no longer able to be sold
- Patch route created to activate or deactivate an item
- Updated seed file with more specific names and associations through specific merchants
- All tests passing