### PR TITLE
Activate items

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -10,7 +10,11 @@ class Merchant::ItemsController < Merchant::BaseController
       item = Item.find(params[:item_id])
       item.toggle!(:active?)
       flash[:notice] = "#{item.name} is now deactivated and is no longer for sale."
-      redirect_to merchant_user_items_path
+    elsif params[:activate_deactivate] == 'activate'
+      item = Item.find(params[:item_id])
+      item.toggle!(:active?)
+      flash[:notice] = "#{item.name} is now activated and available for sale."
     end
+    redirect_to merchant_user_items_path
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -14,8 +14,6 @@
         <p> <%= item.description unless @merchant%> </p>
         <p>Price: <%=number_to_currency(item.price) %> </p>
         <p>Inventory: <%= item.inventory %> </p>
-        <% if !@merchant %>
-        <% end %>
         <% if item.active? %>
           <p>Active</p>
         <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
       <%= link_to "All Items", "/items"%>
       <% if current_user %>
         <%= link_to "Log Out", "/logout", method: :delete %>
-        <p>Logged in as: <%= link_to "#{current_user.name}", "/profile" %></p>
+        <%= link_to "Logged in as: #{current_user.name}", "/profile" %>
       <% else %>
         <%= link_to "Register", "/register"%>
         <%= link_to "Log In", "/login"%>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,10 +1,16 @@
 <h1>All My Items</h1>
 
-<% @items.each do |item| %>
-  <section id= "item-<%= item.id %>">
-    <%= item.name %>
-    <% if item.active? %>
-      <%= link_to 'Deactivate Item', "/merchant/items/#{item.id}/deactivate", method: :patch %>
-    <% end %>
-  </section>
-<% end %>
+<section class="grid-container">
+  <% @items.each do |item| %>
+    <section class = "grid-item" id= "item-<%= item.id %>">
+      <%= item.name %>
+      <% if item.active? %>
+        <p>Active</p>
+        <%= link_to 'Deactivate Item', "/merchant/items/#{item.id}/deactivate", method: :patch %>
+      <% else %>
+        <p>Inactive</p>
+        <%= link_to 'Activate Item', "/merchant/items/#{item.id}/activate", method: :patch %>
+      <% end %>
+    </section>
+  <% end %>
+</section>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,6 +51,7 @@ user = User.create(name: 'User', address: '123 Main', city: 'Denver', state: 'CO
 user = bike_shop.users.create(name: 'Merchant Employee', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'merchant_employee@user.com', password: 'secure', role: 1)
 
 # merchant admin
+user = bike_shop.users.create(name: 'Merchant Admin', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'merchant_admin@user.com', password: 'secure', role: 2)
 
 # site admin
 user = User.create(name: 'Site Admin', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)

--- a/spec/features/users/merchant_items_spec.rb
+++ b/spec/features/users/merchant_items_spec.rb
@@ -1,59 +1,83 @@
 require 'rails_helper'
 
 RSpec.describe 'As a Merchant Admin' do
+  before(:each) do
+    @meg = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+    @merchant_admin = @meg.users.create(
+      name: 'Admin',
+      address: '123 Main',
+      city: 'Denver',
+      state: 'CO',
+      zip: 80_233,
+      email: 'bobemail.com',
+      password: 'secure',
+      role: 2
+    )
+    @user = User.create!(
+      name: 'User',
+      address: '123 Main',
+      city: 'Denver',
+      state: 'CO',
+      zip: 80_233,
+      email: 'useremail.com',
+      password: 'secure'
+    )
+
+    @tire = @meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+    @pump = @meg.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', active?: false, inventory: 15)
+
+    @order_1 = @user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
+    @order_2 = @user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
+
+    @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin)
+
+    visit merchant_user_items_path
+  end
+
   describe 'on my items page' do
     it 'I see a link to deactivate an active item' do
-      meg = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
-      merchant_admin = meg.users.create(
-        name: 'Admin',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure',
-        role: 2
-      )
-      user = User.create!(
-        name: 'User',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'user@email.com',
-        password: 'secure'
-      )
 
-      tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
-      helmet = meg.items.create(name: 'Helmet', description: 'Protects your brain. Try it!', price: 15, image: 'https://www.rei.com/media/product/1289320004', inventory: 20)
-      pump = meg.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', active?: false, inventory: 15)
-
-      order_1 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
-      order_2 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
-
-      order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
-      order_2.item_orders.create!(item: helmet, price: helmet.price, quantity: 2)
-
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_admin)
-
-      visit merchant_user_items_path
-
-      within "#item-#{pump.id}" do
+      within "#item-#{@pump.id}" do
+        expect(page).to have_content('Inactive')
         expect(page).to_not have_link('Deactivate Item')
       end
 
-      within "#item-#{tire.id}" do
+      within "#item-#{@tire.id}" do
+        expect(page).to have_content('Active')
         expect(page).to have_link('Deactivate Item')
         click_link 'Deactivate Item'
       end
 
       expect(current_path).to eq(merchant_user_items_path)
 
-      tire.reload
+      @tire.reload
 
-      expect(page).to have_content("#{tire.name} is now deactivated and is no longer for sale.")
+      expect(page).to have_content("#{@tire.name} is now deactivated and is no longer for sale.")
 
-      expect(tire.active?).to eq(false)
+      expect(@tire.active?).to eq(false)
+    end
+
+    it 'I see a link to activate an inactive item' do
+      within "#item-#{@tire.id}" do
+        expect(page).to have_content('Active')
+        expect(page).to_not have_link('Activate Item')
+      end
+
+      within "#item-#{@pump.id}" do
+        expect(page).to have_content('Inactive')
+        expect(page).to have_link('Activate Item')
+        click_link 'Activate Item'
+      end
+
+      expect(current_path).to eq(merchant_user_items_path)
+
+      @pump.reload
+
+      expect(page).to have_content("#{@pump.name} is now activated and available for sale.")
+
+      expect(@pump.active?).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Complete User Story (#59) – Merchant Admin can activate an inactive item
- All of a merchant's items render as either active/inactive on the merchant admin's items index page
- An inactive item can now be toggled to activate the item, changing the rendered status to be active
- Flash message indicates success
- Added omitted merchant admin to seeds file
- Remove unnecessary code in items index view
- Changed `Logged in as: User Name` in nav bar to be a link for improved presentation
- All tests passing