### PR TITLE
Admin merchant index

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Admin::MerchantsController < Admin::BaseController
+  def show; end
+
+  def toggle_active
+    merchant = Merchant.find(params[:merchant_id])
+    is_enabled = merchant.enabled?
+    merchant.update_attributes(enabled?: !is_enabled)
+    redirect_to merchants_path
+  end
+end

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -2,8 +2,20 @@
 <p align="center"><%= link_to "New Merchant", "/merchants/new" %></p>
 <section class = "grid-container">
   <% @merchants.each do |merchant|%>
-    <section class = "grid-item">
-      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+    <section class = "grid-item" id='merchant-<%= merchant.id %>'>
+      <% if site_admin? %>
+        <p>
+          <%= link_to merchant.name, admin_merchants_path(merchant) %>
+          <%= "#{merchant.city}, #{merchant.state}"%>
+          <% if merchant.enabled? %>
+            <%= link_to 'Disable', admin_merchants_path(merchant), method: :patch %>
+          <% else %> 
+            <%= link_to 'Enable', admin_merchants_path(merchant), method: :patch %>
+          <% end %>
+        </p>
+      <% else %>
+        <p><%= link_to merchant.name, merchants_path(merchant) %></p>
+      <% end %>
     </section>
   <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     get '/users', to: 'users#index'
     get '/users/:user_id', to: 'users#show'
+    get '/merchants/:merchant_id', to: 'merchants#show', as: 'merchants'
+    patch '/merchants/:merchant_id', to: 'merchants#toggle_active'
   end
 
   namespace :merchant do

--- a/db/migrate/20191029012844_add_column_to_merchants.rb
+++ b/db/migrate/20191029012844_add_column_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddColumnToMerchants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :merchants, :enabled?, :boolean, default: true
+  end
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'As an admin user' do
+  describe 'when I navigate to /merchants' do
+    before :each do
+      @bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      @dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210, enabled?: false)
+      @site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@site_admin)
+
+      visit merchants_path
+    end
+
+    it 'it shows all merchants with their name, city, and state' do
+      within "#merchant-#{@bike_shop.id}" do
+        expect(page).to have_link(@bike_shop.name)
+        expect(page).to have_content("#{@bike_shop.city}, #{@bike_shop.state}")
+      end
+
+      within "#merchant-#{@dog_shop.id}" do
+        expect(page).to have_link(@dog_shop.name)
+        expect(page).to have_content("#{@dog_shop.city}, #{@dog_shop.state}")
+      end
+    end
+
+    it 'displays disable/enable links for merchants that are enabled/disabled' do
+      within "#merchant-#{@bike_shop.id}" do
+        click_link 'Disable'
+      end
+      
+      @bike_shop.reload
+      expect(current_path).to eq(merchants_path)
+      expect(@bike_shop.enabled?).to eq(false)
+      
+      within "#merchant-#{@bike_shop.id}" do
+        expect(page).to have_link('Enable')
+      end
+      
+      within "#merchant-#{@dog_shop.id}" do
+        click_link 'Enable'
+      end
+      
+      @dog_shop.reload
+      expect(current_path).to eq(merchants_path)
+      expect(@dog_shop.enabled?).to eq(true)
+
+      within "#merchant-#{@dog_shop.id}" do
+        expect(page).to have_link('Disable')
+      end
+
+    end
+  end
+end
+      


### PR DESCRIPTION
- Added `enabled?` column to merchants table in order to toggle between active and inactive.
- (#51) Admin users can view /merchants with links to their admin merchant show page and can toggle merchants between active and inactive.