### PR TITLE
Add Admin view of Merchant's dashboard

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,7 @@
+class Admin::MerchantsController < ApplicationController
+
+  def show
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,4 +1,4 @@
-class Admin::MerchantsController < ApplicationController
+class Admin::MerchantsController < Admin::BaseController
 
   def show
     @merchant = Merchant.find(params[:merchant_id])

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -6,7 +6,12 @@ class MerchantsController < ApplicationController
   end
 
   def show
-    @merchant = Merchant.find(params[:id])
+    if site_admin?
+      @merchant = Merchant.find(params[:id])
+      redirect_to "/admin/merchants/#{@merchant.id}"
+    else
+      @merchant = Merchant.find(params[:id])
+    end
   end
 
   def new; end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @orders.each do |order| %>
   <article id='order-<%= order.id %>'>
-    <p><%= link_to "#{order.user.name}", admin_users_path(order.user) %></p>
+    <p><%= link_to "#{order.user.name}", "/admin/users/#{order.user.id}" %></p>
     <p><%= "#{order.id}: #{order.status}" %></p>
     <p><%= order.created_at %></p>
     <hr>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,27 @@
+<section id="merchant_details">
+  <h1><%= @merchant.name %></h1>
+  <h3>Merchant Information: </h3>
+  <p><%= @merchant.address %></p>
+  <p><%= "#{@merchant.city}, #{@merchant.state} #{@merchant.zip}" %></p>
+</section>
+
+<br>
+
+<h3>Orders:</h3>
+
+<% @merchant.specific_orders.each do |itemorder| %>
+  <section id="order-<%=itemorder.order_id%>">
+    <p>Order #<%= link_to("#{itemorder.order_id}", merchant_orders_path(itemorder.order_id)) %></p>
+    <p>Date Created: <%= itemorder.order.created_at %></p>
+    <p>Status: <%= itemorder.order.status %></p>
+    <p>Total Quantity: <%= itemorder.order_total_quantity %> </p>
+    <p>Grand Total: <%= number_to_currency(itemorder.order_total_cost) %> </p>
+    <hr>
+  </section>
+<% end %>
+
+<br>
+
+<h3>Current Items for Sale: </h3>
+
+<%= link_to 'View Items', merchant_user_items_path %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -24,4 +24,4 @@
 
 <h3>Current Items for Sale: </h3>
 
-<%= link_to 'View Items', merchant_user_items_path %>
+<%= link_to 'View Items', merchant_items_path %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @users.each do |user| %>
   <article id='user-<%= user.id %>'>
-    <p><%= link_to user.name, admin_users_path(user) %></p>
+    <p><%= link_to user.name, "/admin/users/#{user.id}" %></p>
     <p><%= "Date Registered: #{user.created_at}" %></p>
     <p><%= "Role: #{user.role}" %></p>
   </article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     get '/users', to: 'users#index'
     get '/users/:user_id', to: 'users#show'
+    get '/merchants/:merchant_id', to: 'merchants#show'
   end
 
   namespace :merchant do

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe 'As an Admin User' do
         expect(page).to have_content("Total Quantity: #{order.total_quantity}")
         expect(page).to have_content("Grand Total: $#{order.grand_total}")
       end
+      
+      expect(page).to have_link('View Items')
     end
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'As an Admin User' do
+  describe 'when I visit the merchant index page' do
+    it 'clicking a merchant name redirects to an admin merchant show page idential to that merchants dashboard' do
+      user = User.create!(
+        name: 'User_bob',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'user@email.com',
+        password: 'secure'
+      )
+
+      merchant = Merchant.create!(
+        name: "Brian's Bike Shop",
+        address: '123 Bike Rd.',
+        city: 'Richmond',
+        state: 'VA',
+        zip: 23_137,
+        )
+
+      site_admin = User.create!(
+        name: 'Site Admin',
+        address: '123 First',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'site_admin@user.com',
+        password: 'secure',
+        role: 3)
+
+      pump = merchant.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', inventory: 15)
+      order = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
+      order.item_orders.create!(item: pump, price: pump.price, quantity: 3)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
+
+      visit merchants_path
+
+      click_link merchant.name
+
+      expect(current_path).to eq("/admin/merchants/#{merchant.id}")
+
+      within '#merchant_details' do
+        expect(page).to have_content("Brian's Bike Shop")
+        expect(page).to have_content("123 Bike Rd.\nRichmond, VA 23137")
+      end
+
+      within "#order-#{order.id}" do
+        expect(page).to have_link(order.id.to_s)
+        expect(page).to have_content("Date Created: #{order.created_at}")
+        expect(page).to have_content("Total Quantity: #{order.total_quantity}")
+        expect(page).to have_content("Grand Total: $#{order.grand_total}")
+      end
+    end
+  end
+end

--- a/spec/features/merchant/merchant_dash_spec.rb
+++ b/spec/features/merchant/merchant_dash_spec.rb
@@ -21,6 +21,7 @@ describe 'As a logged in Merchant (employee/admin)' do
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_employee)
   end
+  
   it 'on my dashboard, I see the name and address of the merchant I work for' do
     visit merchant_dashboard_path
 


### PR DESCRIPTION
- (#48) Site Admin can view a specific merchant's dashboard by clicking that merchant's name on the Site Admin Merchants index page
- Added conditional redirect in MerchantsController for site_admin?
- Created new admin/merchants show route and view
- Created new Admin::MerchantsController
- Changed use of path helpers to URI pattern in admin/users and /dashboard index views as the links were not redirecting as expected
- All tests passing