### PR TITLE
Change order ID to not be a link

### DIFF
--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -11,7 +11,7 @@
 
 <% @merchant.specific_orders.each do |itemorder| %>
   <section id="order-<%=itemorder.order_id%>">
-    <p>Order #<%= link_to("#{itemorder.order_id}", merchant_orders_path(itemorder.order_id)) %></p>
+    <p>Order #<%= itemorder.order_id %></p>
     <p>Date Created: <%= itemorder.order.created_at %></p>
     <p>Status: <%= itemorder.order.status %></p>
     <p>Total Quantity: <%= itemorder.order_total_quantity %> </p>

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe 'As an Admin User' do
       end
 
       within "#order-#{order.id}" do
-        expect(page).to have_link(order.id.to_s)
+        expect(page).to have_content(order.id)
         expect(page).to have_content("Date Created: #{order.created_at}")
         expect(page).to have_content("Total Quantity: #{order.total_quantity}")
         expect(page).to have_content("Grand Total: $#{order.grand_total}")
       end
-      
+
       expect(page).to have_link('View Items')
     end
   end


### PR DESCRIPTION
Order ID on Site Admin Merchant show page is no longer a link