### PR TITLE
Admin user order show page

### DIFF
--- a/app/controllers/admin/user_orders_controller.rb
+++ b/app/controllers/admin/user_orders_controller.rb
@@ -1,0 +1,6 @@
+class Admin::UserOrdersController < Admin::BaseController
+
+  def show
+  end
+
+end

--- a/app/controllers/admin/user_orders_controller.rb
+++ b/app/controllers/admin/user_orders_controller.rb
@@ -1,6 +1,7 @@
 class Admin::UserOrdersController < Admin::BaseController
 
   def show
+    @order = Order.find(params[:order_id])
   end
 
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -3,7 +3,7 @@
 <% @orders.each do |order| %>
   <article id='order-<%= order.id %>'>
     <p><%= link_to "#{order.user.name}", "/admin/users/#{order.user.id}" %></p>
-    <p><%= "Order ID: #{order.id}" %></p>
+    <p>Order ID: <%= link_to "#{order.id}", admin_user_order_path(order.user.id, order.id) %></p>
     <p><%= "Order Status: #{order.status}"%></p>
     <p><%= order.created_at %></p>
     <% if order.packaged? %>

--- a/app/views/admin/user_orders/show.html.erb
+++ b/app/views/admin/user_orders/show.html.erb
@@ -1,0 +1,14 @@
+<h1>ID: <%= @order.id %></h1>
+<article id='order-info'>
+  <%= render partial: 'partials/order_info',
+    locals: {
+      id: @order.id,
+      created_at: @order.created_at,
+      updated_at: @order.updated_at,
+      status: @order.status,
+      item_orders: @order.item_orders,
+      total_quantity: @order.total_quantity,
+      grand_total: @order.grand_total
+    }
+  %>
+</article>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -10,3 +10,10 @@
     }
   %>
 </section>
+<br>
+<section id='user-order-links'>
+  <h3> <%= @user.name %>'s Orders</h3>
+  <% @user.orders.each do |order| %>
+    <p>Order ID: <%= link_to "#{order.id}", admin_user_order_path(@user.id, order.id)%></p>
+  <% end %>
+</section>

--- a/app/views/partials/_order_info.html.erb
+++ b/app/views/partials/_order_info.html.erb
@@ -8,10 +8,10 @@
       <p>Description: <%= item_order.item.description %></p>
       <img src= <%= item_order.item.image %>>
       <p>Quantity: <%= item_order.quantity %></p>
-      <p>Price: <%= item_order.price %></p>
-      <p>Subtotal: <%= item_order.subtotal %></p>
+      <p>Price: <%= number_to_currency(item_order.price) %></p>
+      <p>Subtotal: <%= number_to_currency(item_order.subtotal) %></p>
     </article>
   <% end %>
 <% end %>
 <p>Total Quantity: <%= total_quantity %></p>
-<p>Grand Total: <%= grand_total %></p>
+<p>Grand Total: <%= number_to_currency(grand_total) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     get '/users', to: 'users#index'
     get '/users/:user_id', to: 'users#show'
+    get '/users/:user_id/orders/:order_id', to: 'user_orders#show', as: 'user_order'
     patch '/orders/:order_id', to: 'dashboard#update_order_status'
     get '/merchants/:merchant_id', to: 'merchants#show', as: 'merchants'
     patch '/merchants/:merchant_id', to: 'merchants#toggle_active'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/', to: 'dashboard#index'
     get '/users', to: 'users#index'
-    get '/users/:user_id', to: 'users#show'
+    get '/users/:user_id', to: 'users#show', as: 'user_show'
     get '/users/:user_id/orders/:order_id', to: 'user_orders#show', as: 'user_order'
     patch '/orders/:order_id', to: 'dashboard#update_order_status'
     get '/merchants/:merchant_id', to: 'merchants#show', as: 'merchants'

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'As an admin user' do
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@site_admin)
     end
+
     it 'it shows all orders and the user for that order' do
       visit admin_path
 
@@ -84,6 +85,29 @@ RSpec.describe 'As an admin user' do
       within "#order-#{@order_3.id}" do
         expect(page).to_not have_button('Ship')
       end
+    end
+
+    it 'the order ID is a link to an admin-only view of that order' do
+      visit admin_path
+
+      within "#order-#{@order_1.id}" do
+        expect(page).to have_link(@order_1.id)
+      end
+
+      within "#order-#{@order_2.id}" do
+        expect(page).to have_link(@order_2.id)
+      end
+
+      within "#order-#{@order_3.id}" do
+        expect(page).to have_link(@order_3.id)
+      end
+
+      within "#order-#{@order_4.id}" do
+        expect(page).to have_link(@order_4.id)
+        click_link "#{@order_4.id}"
+      end
+
+      expect(current_path).to eq(admin_user_order_path(@user_1.id, @order_4.id))
     end
   end
 end

--- a/spec/features/admin/user_orders/show_spec.rb
+++ b/spec/features/admin/user_orders/show_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'As an Admin User' do
+  describe 'when I visit a user\'s profile' do
+    it 'I can click a link and view the user\'s order show page' do
+      user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
+      dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
+      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)
+      tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+      pull_toy = dog_shop.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
+      order_1 = user_1.orders.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 2)
+      item_order_1 = order_1.item_orders.create(order_id: order_1.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id)
+      item_order_2 = order_1.item_orders.create(order_id: order_1.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id)
+
+      site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
+
+      visit admin_user_show_path(user_1.id)
+
+      within '#user-order-links' do
+        expect(page).to have_link(order_1.id)
+        click_on "#{order_1.id}"
+      end
+
+      expect(current_path).to eq(admin_user_order_path(user_1.id, order_1.id))
+
+      within '#order-info' do
+        expect(page).to have_content("Date Created: #{order_1.created_at}")
+        expect(page).to have_content("Last Updated: #{order_1.updated_at}")
+        expect(page).to have_content("Status: #{order_1.status}")
+        expect(page).to have_content("Total Quantity: #{order_1.total_quantity}")
+        expect(page).to have_content("Grand Total: #{order_1.grand_total}")
+      end
+
+      within "#item-order-#{item_order_1.id}" do
+        expect(page).to have_content("Name: #{tire.name}")
+        expect(page).to have_content("Description: #{tire.description}")
+        expect(page).to have_css("img[src*='#{tire.image}']")
+        expect(page).to have_content("Quantity: #{item_order_1.quantity}")
+        expect(page).to have_content("Price: #{item_order_1.price}")
+        expect(page).to have_content("Subtotal: #{item_order_1.subtotal}")
+      end
+
+      within "#item-order-#{item_order_2.id}" do
+        expect(page).to have_content("Name: #{pull_toy.name}")
+        expect(page).to have_content("Description: #{pull_toy.description}")
+        expect(page).to have_css("img[src*='#{pull_toy.image}']")
+        expect(page).to have_content("Quantity: #{item_order_2.quantity}")
+        expect(page).to have_content("Price: #{item_order_2.price}")
+        expect(page).to have_content("Subtotal: #{item_order_2.subtotal}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- User Story 53, EXTENSION: Admin links to User's Order Show from Admin Dashboard
- User Story 54, EXTENSION: Admin views a User's Order Show Page
- Admin user can link to and view individual user's order show pages via Order ID links on the Admin dashboard and a user's profile page
- The order info is the same as what a user sees
- Modified order_info partial to transform number to currency
- All tests passing 
