### PR TITLE
Admin user toggle

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -6,7 +6,7 @@ class Admin::MerchantsController < Admin::BaseController
     @merchant = Merchant.find(params[:merchant_id])
   end
 
-  def toggle_active
+  def toggle_enabled
     merchant = Merchant.find(params[:merchant_id])
     is_enabled = merchant.enabled?
     merchant.update_attributes(enabled?: !is_enabled)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,4 +8,16 @@ class Admin::UsersController < Admin::BaseController
   def show
     @user = User.find(params[:user_id])
   end
+
+  def toggle_enabled
+    user = User.find(params[:user_id])
+    is_enabled = user.enabled?
+    user.update_attributes(enabled?: !is_enabled)
+    if !is_enabled
+      flash[:notice] = "#{user.name} has been enabled!"
+    else
+      flash[:notice] = "#{user.name} has been disabled!"
+    end
+    redirect_to admin_users_path
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,12 +11,9 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:email])
     if user&.authenticate(params[:password])
-      session[:user_id] = user.id
-      flash[:success] = "Welcome back, #{user.name}!"
-      redirect_login
+      user.enabled? ? user_login_redirect(user) : user_disabled_render
     else
-      flash.now[:error] = 'The email and password you entered did not match our records. Please double-check and try again.'
-      render :login
+      user_error_render
     end
   end
 
@@ -36,5 +33,21 @@ class SessionsController < ApplicationController
     else
       redirect_to profile_path
     end
+  end
+
+  def user_login_redirect(user)
+    session[:user_id] = user.id
+    flash[:success] = "Welcome back, #{user.name}!"
+    redirect_login
+  end
+
+  def user_error_render
+    flash.now[:error] = 'The email and password you entered did not match our records. Please double-check and try again.'
+    render :login
+  end
+
+  def user_disabled_render
+    flash.now[:error] = "Your user account is disabled!"
+    render :login
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -10,6 +10,8 @@ class Merchant < ApplicationRecord
                         :city,
                         :state,
                         :zip
+  
+  validates_inclusion_of :enabled?, in: [true, false]
 
   def no_orders?
     item_orders.empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   validates_uniqueness_of :email
   validates_presence_of :password_digest
 
+  validates_inclusion_of :enabled?, in: [true, false]
+
   validates_length_of :zip, is: 5
   validates_numericality_of :zip
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -5,5 +5,10 @@
     <p><%= link_to user.name, "/admin/users/#{user.id}" %></p>
     <p><%= "Date Registered: #{user.created_at}" %></p>
     <p><%= "Role: #{user.role}" %></p>
+    <% if user.enabled? %>
+      <p><%= link_to 'Disable', "/admin/users/#{user.id}", method: :patch %></p>
+    <% else %>
+      <p><%= link_to 'Enable', "/admin/users/#{user.id}", method: :patch %></p>
+    <% end %>
   </article>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,9 +41,10 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     get '/users', to: 'users#index'
     get '/users/:user_id', to: 'users#show'
+    patch '/users/:user_id', to: 'users#toggle_enabled'
     patch '/orders/:order_id', to: 'dashboard#update_order_status'
     get '/merchants/:merchant_id', to: 'merchants#show', as: 'merchants'
-    patch '/merchants/:merchant_id', to: 'merchants#toggle_active'
+    patch '/merchants/:merchant_id', to: 'merchants#toggle_enabled'
   end
 
   namespace :merchant do

--- a/db/migrate/20191029222921_add_column_to_users.rb
+++ b/db/migrate/20191029222921_add_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :enabled?, :boolean, default: true
+  end
+end

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -91,19 +91,19 @@ RSpec.describe 'As an admin user' do
       visit admin_path
 
       within "#order-#{@order_1.id}" do
-        expect(page).to have_link(@order_1.id)
+        expect(page).to have_link("#{@order_1.id}")
       end
 
       within "#order-#{@order_2.id}" do
-        expect(page).to have_link(@order_2.id)
+        expect(page).to have_link("#{@order_2.id}")
       end
 
       within "#order-#{@order_3.id}" do
-        expect(page).to have_link(@order_3.id)
+        expect(page).to have_link("#{@order_3.id}")
       end
 
       within "#order-#{@order_4.id}" do
-        expect(page).to have_link(@order_4.id)
+        expect(page).to have_link("#{@order_4.id}")
         click_link "#{@order_4.id}"
       end
 

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -2,40 +2,80 @@ require 'rails_helper'
 
 RSpec.describe 'As an admin user' do
   describe 'when I click the "Users" link in the nav' do
-    it 'it shows all users and their info' do
-      dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
-      user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
-      dog_employee = dog_shop.users.create(name: 'Dog Employee', address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210, email: 'dog_employee@user.com', password: 'secure', role: 1)
-      dog_admin = dog_shop.users.create(name: 'Dog Admin', address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210, email: 'dog_admin@user.com', password: 'secure', role: 2)
-      site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+    before :each do
+      @dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
+      @user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user.com', password: 'secure', role: 0)
+      @dog_employee = @dog_shop.users.create(name: 'Dog Employee', address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210, email: 'dog_employee@user.com', password: 'secure', role: 1, enabled?: false)
+      @dog_admin = @dog_shop.users.create(name: 'Dog Admin', address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210, email: 'dog_admin@user.com', password: 'secure', role: 2, enabled?: false)
+      @site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@site_admin)
 
       visit admin_users_path
+    end
+    it 'it shows all users and their info' do
 
-      within "#user-#{user_1.id}" do
-        expect(page).to have_link(user_1.name)
-        expect(page).to have_content("Date Registered: #{user_1.created_at}")
-        expect(page).to have_content("Role: #{user_1.role}")
+      within "#user-#{@user_1.id}" do
+        expect(page).to have_link(@user_1.name)
+        expect(page).to have_content("Date Registered: #{@user_1.created_at}")
+        expect(page).to have_content("Role: #{@user_1.role}")
       end
 
-      within "#user-#{dog_employee.id}" do
-        expect(page).to have_link(dog_employee.name)
-        expect(page).to have_content("Date Registered: #{dog_employee.created_at}")
-        expect(page).to have_content("Role: #{dog_employee.role}")
+      within "#user-#{@dog_employee.id}" do
+        expect(page).to have_link(@dog_employee.name)
+        expect(page).to have_content("Date Registered: #{@dog_employee.created_at}")
+        expect(page).to have_content("Role: #{@dog_employee.role}")
       end
 
-      within "#user-#{dog_admin.id}" do
-        expect(page).to have_link(dog_admin.name)
-        expect(page).to have_content("Date Registered: #{dog_admin.created_at}")
-        expect(page).to have_content("Role: #{dog_admin.role}")
+      within "#user-#{@dog_admin.id}" do
+        expect(page).to have_link(@dog_admin.name)
+        expect(page).to have_content("Date Registered: #{@dog_admin.created_at}")
+        expect(page).to have_content("Role: #{@dog_admin.role}")
       end
 
-      within "#user-#{site_admin.id}" do
-        expect(page).to have_link(site_admin.name)
-        expect(page).to have_content("Date Registered: #{site_admin.created_at}")
-        expect(page).to have_content("Role: #{site_admin.role}")
+      within "#user-#{@site_admin.id}" do
+        expect(page).to have_link(@site_admin.name)
+        expect(page).to have_content("Date Registered: #{@site_admin.created_at}")
+        expect(page).to have_content("Role: #{@site_admin.role}")
       end
+    end
+
+    it 'can disable a user account' do
+      within "#user-#{@user_1.id}" do
+        click_link 'Disable'
+      end
+
+      expect(current_path).to eq(admin_users_path)
+
+      expect(page).to have_content("#{@user_1.name} has been disabled!")
+
+      @user_1.reload
+
+      expect(@user_1.enabled?).to eq(false) 
+
+      within "#user-#{@user_1.id}" do
+        expect(page).to have_link('Enable')
+      end
+    end
+
+    it 'can enable a user account' do
+      within "#user-#{@dog_employee.id}" do
+        click_link 'Enable'
+      end
+
+      expect(current_path).to eq(admin_users_path)
+
+      expect(page).to have_content("#{@dog_employee.name} has been enabled!")
+
+      @dog_employee.reload
+
+      expect(@dog_employee.enabled?).to eq(true) 
+
+      within "#user-#{@dog_employee.id}" do
+        expect(page).to have_link('Disable')
+      end
+
+      
     end
   end
 end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -73,9 +73,7 @@ RSpec.describe 'As an admin user' do
 
       within "#user-#{@dog_employee.id}" do
         expect(page).to have_link('Disable')
-      end
-
-      
+      end   
     end
   end
 end

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Cart show' do
           within "#cart-item-#{item.id}" do
             expect(page).to have_link(item.name)
             expect(page).to have_css("img[src*='#{item.image}']")
-            expect(page).to have_link(item.merchant.name.to_s)
+            expect(page).to have_link("#{item.merchant.name}")
             expect(page).to have_content("$#{item.price}")
             expect(page).to have_content('1')
             expect(page).to have_content("$#{item.price}")

--- a/spec/features/items/stats_spec.rb
+++ b/spec/features/items/stats_spec.rb
@@ -38,13 +38,13 @@ describe 'Items Index Page' do
       within '#most-popular-items' do
         expect(page).to have_content('Most Popular Items:')
         expect(page).to have_content("#{@tire.name}: 12 purchased\n#{@lock.name}: 10 purchased\n#{@helmet.name}: 8 purchased\n#{@chain.name}: 6 purchased\n#{@pump.name}: 3 purchased")
-        expect(page).to_not have_content(@seat.name.to_s)
+        expect(page).to_not have_content(@seat.name)
       end
 
       within '#least-popular-items' do
         expect(page).to have_content('Least Popular Items:')
         expect(page).to have_content("#{@seat.name}: 1 purchased\n#{@pump.name}: 3 purchased\n#{@chain.name}: 6 purchased\n#{@helmet.name}: 8 purchased\n#{@lock.name}: 10 purchased")
-        expect(page).to_not have_content(@tire.name.to_s)
+        expect(page).to_not have_content(@tire.name)
       end
     end
   end

--- a/spec/features/merchant/merchant_dash_spec.rb
+++ b/spec/features/merchant/merchant_dash_spec.rb
@@ -60,14 +60,14 @@ describe 'As a logged in Merchant (employee/admin)' do
     visit merchant_dashboard_path
 
     within "#order-#{order_1.id}" do
-      expect(page).to have_link(order_1.id.to_s)
+      expect(page).to have_link("#{order_1.id}")
       expect(page).to have_content("Date Created: #{order_1.created_at}")
       expect(page).to have_content("Total Quantity: #{order_1.total_quantity}")
       expect(page).to have_content("Grand Total: $#{order_1.grand_total}")
     end
 
     within "#order-#{order_2.id}" do
-      expect(page).to have_link(order_2.id.to_s)
+      expect(page).to have_link("#{order_2.id}")
       expect(page).to have_content("Date Created: #{order_2.created_at}")
       expect(page).to have_content("Total Quantity: #{order_2.total_quantity}")
       expect(page).to have_content("Grand Total: $#{order_2.grand_total}")

--- a/spec/features/merchant/merchant_orders_spec.rb
+++ b/spec/features/merchant/merchant_orders_spec.rb
@@ -48,11 +48,11 @@ describe 'As a logged in Merchant (employee/admin)' do
   it 'I only see the items in the order that are being purchased from my merchant' do
     expect(current_path).to eq("/merchant/orders/#{@order.id}")
 
-    expect(page).to have_content(@user.name.to_s)
-    expect(page).to have_content(@user.address.to_s)
-    expect(page).to have_content(@user.city.to_s)
-    expect(page).to have_content(@user.state.to_s)
-    expect(page).to have_content(@user.zip.to_s)
+    expect(page).to have_content(@user.name)
+    expect(page).to have_content(@user.address)
+    expect(page).to have_content(@user.city)
+    expect(page).to have_content(@user.state)
+    expect(page).to have_content(@user.zip)
 
     within "#item-#{@pump.id}" do
       expect(page).to have_content(@pump.name)

--- a/spec/features/orders/creation_spec.rb
+++ b/spec/features/orders/creation_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe('Order Creation') do
 
       within "#item-#{@paper.id}" do
         expect(page).to have_link(@paper.name)
-        expect(page).to have_link(@paper.merchant.name.to_s)
+        expect(page).to have_link("#{@paper.merchant.name}")
         expect(page).to have_content("$#{@paper.price}")
         expect(page).to have_content('2')
         expect(page).to have_content('$40')
@@ -71,7 +71,7 @@ RSpec.describe('Order Creation') do
 
       within "#item-#{@tire.id}" do
         expect(page).to have_link(@tire.name)
-        expect(page).to have_link(@tire.merchant.name.to_s)
+        expect(page).to have_link("#{@tire.merchant.name}")
         expect(page).to have_content("$#{@tire.price}")
         expect(page).to have_content('1')
         expect(page).to have_content('$100')
@@ -79,7 +79,7 @@ RSpec.describe('Order Creation') do
 
       within "#item-#{@pencil.id}" do
         expect(page).to have_link(@pencil.name)
-        expect(page).to have_link(@pencil.merchant.name.to_s)
+        expect(page).to have_link("#{@pencil.merchant.name}")
         expect(page).to have_content("$#{@pencil.price}")
         expect(page).to have_content('1')
         expect(page).to have_content('$2')

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe('New Order Page') do
 
       within "#order-item-#{@tire.id}" do
         expect(page).to have_link(@tire.name)
-        expect(page).to have_link(@tire.merchant.name.to_s)
+        expect(page).to have_link("#{@tire.merchant.name}")
         expect(page).to have_content("$#{@tire.price}")
         expect(page).to have_content('1')
         expect(page).to have_content('$100')
@@ -45,7 +45,7 @@ RSpec.describe('New Order Page') do
 
       within "#order-item-#{@paper.id}" do
         expect(page).to have_link(@paper.name)
-        expect(page).to have_link(@paper.merchant.name.to_s)
+        expect(page).to have_link("#{@paper.merchant.name}")
         expect(page).to have_content("$#{@paper.price}")
         expect(page).to have_content('2')
         expect(page).to have_content('$40')
@@ -53,7 +53,7 @@ RSpec.describe('New Order Page') do
 
       within "#order-item-#{@pencil.id}" do
         expect(page).to have_link(@pencil.name)
-        expect(page).to have_link(@pencil.merchant.name.to_s)
+        expect(page).to have_link("#{@pencil.merchant.name}")
         expect(page).to have_content("$#{@pencil.price}")
         expect(page).to have_content('1')
         expect(page).to have_content('$2')

--- a/spec/features/reviews/edit_spec.rb
+++ b/spec/features/reviews/edit_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'review edit and update', type: :feature do
       expect(current_path).to eq("/reviews/#{review_1.id}/edit")
       expect(find_field(:title).value).to eq(review_1.title)
       expect(find_field(:content).value).to eq(review_1.content)
-      expect(find_field(:rating).value).to eq(review_1.rating.to_s)
+      expect(find_field(:rating).value).to eq("#{review_1.rating}")
 
       fill_in :title, with: title
       fill_in :content, with: content

--- a/spec/features/user_orders/index_spec.rb
+++ b/spec/features/user_orders/index_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'As a registered user' do
       visit profile_orders_path
 
       within "#order-#{order_1.id}" do
-        expect(page).to have_link(order_1.id.to_s)
+        expect(page).to have_link("#{order_1.id}")
         expect(page).to have_content("Date Created: #{order_1.created_at}")
         expect(page).to have_content("Last Updated: #{order_1.updated_at}")
         expect(page).to have_content("Status: #{order_1.status}")

--- a/spec/features/users/user_login_spec.rb
+++ b/spec/features/users/user_login_spec.rb
@@ -52,6 +52,28 @@ RSpec.describe 'As a User' do
       expect(find_field(:password).value).to eq(nil)
     end
 
+    it 'cannot login if the user is disabled' do
+      user = User.create(
+        name: 'Bob',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'bob@email.com',
+        password: 'secure',
+        enabled?: false
+      )
+
+      fill_in :email, with: user.email
+      fill_in :password, with: user.password
+
+      click_on 'Sign me in'
+
+      expect(page).to have_content("Your user account is disabled!")
+      expect(find_field(:email).value).to eq(nil)
+      expect(find_field(:password).value).to eq(nil)
+    end
+
     describe 'as a regular user' do
       it 'when I enter my valid credentials, I am redirected to my profile page' do
         user = User.create(

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -9,6 +9,7 @@ describe Merchant, type: :model do
     it { should validate_presence_of :city }
     it { should validate_presence_of :state }
     it { should validate_presence_of :zip }
+    it { should_not allow_value(nil).for(:enabled?) }
   end
 
   describe 'relationships' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,7 @@ describe User, type: :model do
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:email) }
     it { should validate_presence_of(:password) }
+    it { should_not allow_value(nil).for(:enabled?) }
   end
 
   describe 'relationships' do


### PR DESCRIPTION
- Extension 57/58: Site admin can enable/disable users.
- Disabled users cannot log in.
- Refactor tests to use string interpolation when dealing with links and IDs.
