### PR TITLE
Admin cancel order

### DIFF
--- a/app/controllers/admin/user_orders_controller.rb
+++ b/app/controllers/admin/user_orders_controller.rb
@@ -4,4 +4,15 @@ class Admin::UserOrdersController < Admin::BaseController
     @order = Order.find(params[:order_id])
   end
 
+  def update
+    order = Order.where(id: params[:order_id], user_id: params[:user_id]).first
+    order.update(status: 'Cancelled')
+    order.item_orders.each do |item_order|
+      item_order.return_inventory if item_order.status == 'Fulfilled'
+      item_order.update_attributes(status: 'Unfulfilled')
+    end
+    flash[:notice] = 'Order has been cancelled!'
+    redirect_to admin_users_path(params[:user_id])
+  end
+
 end

--- a/app/views/admin/user_orders/show.html.erb
+++ b/app/views/admin/user_orders/show.html.erb
@@ -11,4 +11,7 @@
       grand_total: @order.grand_total
     }
   %>
+<% if @order.status == 'Pending' %>
+  <p><%= link_to 'Cancel Order', admin_user_order_update_path(@order.user.id, @order.id), method: :patch %>
+<% end %>
 </article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
     get '/users/:user_id', to: 'users#show'
     patch '/users/:user_id', to: 'users#toggle_enabled'
     get '/users/:user_id/orders/:order_id', to: 'user_orders#show', as: 'user_order'
+    patch '/users/:user_id/orders/:order_id', to: 'user_orders#update', as: 'user_order_update'
     patch '/orders/:order_id', to: 'dashboard#update_order_status'
     get '/merchants/:merchant_id', to: 'merchants#show', as: 'merchants'
     patch '/merchants/:merchant_id', to: 'merchants#toggle_enabled'

--- a/spec/features/admin/user_orders/show_spec.rb
+++ b/spec/features/admin/user_orders/show_spec.rb
@@ -50,5 +50,63 @@ RSpec.describe 'As an Admin User' do
         expect(page).to have_content("Subtotal: $#{item_order_2.subtotal}")
       end
     end
+
+    describe 'then click a link to visit a user\'s order show page' do
+      it 'it displays a link to cancel the order' do
+        user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
+        dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
+        bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)
+        tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+        pull_toy = dog_shop.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
+        order_1 = user_1.orders.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 0)
+        item_order_1 = order_1.item_orders.create(order_id: order_1.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id, status: 1)
+        item_order_2 = order_1.item_orders.create(order_id: order_1.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id, status: 0)
+
+        site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
+
+        visit "/admin/users/#{user_1.id}/orders/#{order_1.id}"
+
+        within '#order-info' do
+          click_link 'Cancel Order'
+        end
+
+        expect(current_path).to eq(admin_users_path(user_1.id))
+        expect(page).to have_content('Order has been cancelled!')
+
+        tire.reload
+        order_1.reload
+        item_order_1.reload
+        item_order_2.reload
+
+        expect(tire.inventory).to eq(14)
+        expect(pull_toy.inventory).to eq(32)
+        expect(order_1.status).to eq('Cancelled')
+        expect(item_order_1.status).to eq('Unfulfilled')
+        expect(item_order_2.status).to eq('Unfulfilled')
+      end
+
+      it 'it does not display a link to cancel an order that is Packaged' do
+        user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
+        dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
+        bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)
+        tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+        pull_toy = dog_shop.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
+        order_1 = user_1.orders.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 1)
+        item_order_1 = order_1.item_orders.create(order_id: order_1.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id, status: 1)
+        item_order_2 = order_1.item_orders.create(order_id: order_1.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id, status: 1)
+
+        site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
+
+        visit "/admin/users/#{user_1.id}/orders/#{order_1.id}"
+
+        within '#order-info' do
+          expect(page).to_not have_link('Cancel Order')
+        end
+      end
+    end
   end
 end

--- a/spec/features/admin/user_orders/show_spec.rb
+++ b/spec/features/admin/user_orders/show_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'As an Admin User' do
     end
 
     describe 'then click a link to visit a user\'s order show page' do
-      it 'it displays a link to cancel the order' do
+      it 'it displays a link to cancel an order that is Pending' do
         user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
         dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
         bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)


### PR DESCRIPTION
-  User story #55, Extension: Admin can cancel a pending user's order from the order show page