### PR TITLE
Admin edits user profile data

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -20,4 +20,24 @@ class Admin::UsersController < Admin::BaseController
     end
     redirect_to admin_users_path
   end
+
+  def edit_profile
+    @user = User.find(params[:user_id])
+  end
+
+  def update_profile
+    @user = User.find(params[:user_id])
+    if @user.update(user_profile_params)
+      flash[:success] = "#{@user.name}'s profile data has been updated!"
+      redirect_to "/admin/users/#{@user.id}"
+    else
+      flash.now[:error] = @user.errors.full_messages.uniq.to_sentence
+      render :edit_profile
+    end
+  end
+
+  private
+    def user_profile_params
+      params.permit(:name, :address, :city, :state, :zip, :email)
+    end
 end

--- a/app/views/admin/users/edit_profile.html.erb
+++ b/app/views/admin/users/edit_profile.html.erb
@@ -1,0 +1,13 @@
+<%= form_tag admin_update_user_profile_path(@user.id), method: :patch do %>
+  <%=
+    render partial: 'partials/user_form_template', locals: {
+      name: @user.name,
+      address: @user.address,
+      city: @user.city,
+      state: @user.state,
+      zip: @user.zip,
+      email: @user.email
+    }
+  %>
+  <p><%= submit_tag "Update Profile" %></p>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,6 +9,7 @@
       email: @user.email
     }
   %>
+  <p><%= link_to 'Edit Profile', "/admin/users/#{@user.id}/edit" %></p>
 </section>
 <br>
 <section id='user-order-links'>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -38,10 +38,9 @@
           <td><p> There are not enough <%= item_order.item.name %> in inventory to fullfill this order </p></td>
         <% elsif @order.status == 3  %>
           <td><p> This order has been cancelled </p></td>
-        <% else item_order.status == "Unfulfilled" %>
+        <% elsif item_order.status == "Unfulfilled" %>
           <td><p><%= link_to "Fulfill Order: #{item_order.item.name}", "/merchant/orders/#{item_order.order_id}/#{item_order.id}/fulfill", method: :patch %> </p></td>
-        <% end %>
-        <% if (item_order.item.inventory > item_order.quantity) && (item_order.status == 'Fulfilled') %>
+        <% else (item_order.item.inventory > item_order.quantity) && (item_order.status == 'Fulfilled') %>
           <td><p> <%= item_order.status %></p></td>
         <% end %>
       </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
     get '/users', to: 'users#index'
     get '/users/:user_id', to: 'users#show'
     patch '/users/:user_id', to: 'users#toggle_enabled'
+    get '/users/:user_id/edit', to: 'users#edit_profile'
+    patch '/users/:user_id/update', to: 'users#update_profile', as: 'update_user_profile'
     get '/users/:user_id/orders/:order_id', to: 'user_orders#show', as: 'user_order'
     patch '/users/:user_id/orders/:order_id', to: 'user_orders#update', as: 'user_order_update'
     patch '/orders/:order_id', to: 'dashboard#update_order_status'

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe 'As an admin user' do
+  describe 'when I visit a user\'s profile page' do
+    before(:each) do
+      @user = User.create(
+        name: 'Bob',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'bob@email.com',
+        password: 'secure'
+      )
+
+      @site_admin = User.create(
+        name: 'Site Admin',
+        address: '123 First',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'site_admin@user.com',
+        password: 'secure',
+        role: 3)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@site_admin)
+    end
+
+    it 'I can click on a link to edit that user\'s profile data' do
+      visit "/admin/users/#{@user.id}"
+
+      within '#user-info' do
+        click_on 'Edit Profile'
+      end
+
+      expect(current_path).to eq("/admin/users/#{@user.id}/edit")
+    end
+
+    it 'is prepopulated with that user\'s previous data' do
+      visit "/admin/users/#{@user.id}/edit"
+
+      expect(find_field(:name).value).to eq(@user.name)
+      expect(find_field(:address).value).to eq(@user.address)
+      expect(find_field(:city).value).to eq(@user.city)
+      expect(find_field(:state).value).to eq(@user.state)
+      expect(find_field(:zip).value).to eq(@user.zip)
+      expect(find_field(:email).value).to eq(@user.email)
+    end
+
+    it 'edited data shows on the profile page' do
+      visit "/admin/users/#{@user.id}/edit"
+
+      fill_in :name, with: 'Bob'
+      fill_in :address, with: '542 Oak Ave'
+      fill_in :city, with: 'Boulder'
+      fill_in :state, with: 'Colorado'
+      fill_in :zip, with: 80_001
+      fill_in :email, with: 'bob@email.com'
+
+      click_button 'Update Profile'
+
+      expect(current_path).to eq("/admin/users/#{@user.id}")
+
+      expect(page).to have_content("#{@user.name}'s profile data has been updated!")
+
+      within '#user-info' do
+        expect(page).to have_content('Bob')
+        expect(page).to have_content('542 Oak Ave')
+        expect(page).to have_content('Boulder')
+        expect(page).to have_content('Colorado')
+        expect(page).to have_content('80001')
+        expect(page).to have_content('bob@email.com')
+      end
+    end
+
+    it 'cannot be edited with an email already in use' do
+      user = User.create(
+        name: 'Bob',
+        address: '123 Main',
+        city: 'Denver',
+        state: 'CO',
+        zip: 80_233,
+        email: 'not_bob@email.com',
+        password: 'secure'
+      )
+
+      visit "/admin/users/#{@user.id}/edit"
+
+      fill_in :email, with: 'not_bob@email.com'
+
+      click_button 'Update Profile'
+
+      expect(page).to have_content('Email has already been taken')
+
+      expect(find_field(:name).value).to eq(@user.name)
+    end
+  end
+end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'As an admin user' do
   describe 'when I visit a specific users profile page ' do
-    it 'it shows the same info the user would see on their profile page but the admin cannot edit the profile' do
+    it 'it shows the same info the user would see on their profile page' do
       user = User.create(
         name: 'Bob',
         address: '123 Main',
@@ -16,9 +16,9 @@ RSpec.describe 'As an admin user' do
       site_admin = User.create(
         name: 'Site Admin',
         address: '123 First',
-        city: 'Denver', 
+        city: 'Denver',
         state: 'CO',
-        zip: 80_233, 
+        zip: 80_233,
         email: 'site_admin@user.com',
         password: 'secure',
         role: 3)
@@ -34,7 +34,7 @@ RSpec.describe 'As an admin user' do
         expect(page).to have_content('State: CO')
         expect(page).to have_content('Zip: 80233')
         expect(page).to have_content('Email: bob@email.com')
-        expect(page).to_not have_link('Edit Profile')
+        expect(page).to have_link('Edit Profile')
         expect(page).to_not have_link('Edit Password')
       end
     end


### PR DESCRIPTION
- User story 56, Extension - Site admin user can edit a users profile data 
- Fixed merchant user order show view; when a merchant user fulfills an order the fulfill order link next to the item is removed 